### PR TITLE
Fix windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,8 @@ node_js:
   - "14"
   - "node"
 
+os:
+  - "linux"
+  - "windows"
+
 after_script: "npm run coveralls"

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,8 @@ exports.walk = async (mo, path, options = {}) => {
         const filename = entryFilename(dirname, entry);
         const extname = Path.extname(entry.name);
         if (extname === '.mjs' || (defaultToESM && extname === '.js')) {
-            const value = await import(filename);
+            const url = Url.pathToFileURL(filename).href; // Relates to windows, see nodejs/node#31710
+            const value = await import(url);
             await visit(value, filename, entry.name, 'esm');
         }
         else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const Assert = require('assert');
 const { promises: Fs } = require('fs');
 const Path = require('path');
+const Url = require('url');
 const PkgUp = require('pkg-up');
 
 const internals = {};
@@ -145,8 +146,11 @@ internals.tryToResolveCJS = (path) => {
 
 internals.tryToResolveESM = async (filepath) => {
 
+    // Handles edge-case around windows import() requiring a file URL to disambiguate the C:/, see nodejs/node#31710
+    const url = Url.pathToFileURL(filepath).href;
+
     try {
-        return [await import(filepath), filepath, 'esm'];
+        return [await import(url), filepath, 'esm'];
     }
     catch (err) {
         Assert.ok(err.code === 'ERR_MODULE_NOT_FOUND' && err.message.includes(`'${filepath}'`), err);

--- a/test/index.js
+++ b/test/index.js
@@ -194,8 +194,9 @@ describe('MoWalk', () => {
 
         const visitsA = [];
 
+        const v = Path.sep;
         await Mo.walk(module, 'closet/kitchen-sink', {
-            include: (path) => path.includes('kitchen-sink/x/'),
+            include: (path) => path.includes(`kitchen-sink${v}x${v}`),
             visit: (value, path, filename) => {
 
                 visitsA.push([value, filename, relativize(path)]);
@@ -231,8 +232,9 @@ describe('MoWalk', () => {
 
         const visitsA = [];
 
+        const v = Path.sep;
         await Mo.walk(module, 'closet/kitchen-sink', {
-            exclude: (path) => !path.includes('kitchen-sink/x/'),
+            exclude: (path) => !path.includes(`kitchen-sink${v}x${v}`),
             visit: (value, path, filename) => {
 
                 visitsA.push([value, filename, relativize(path)]);
@@ -268,8 +270,9 @@ describe('MoWalk', () => {
 
         const visits = [];
 
+        const v = Path.sep;
         await Mo.walk(module, 'closet/kitchen-sink', {
-            include: (path) => path.includes('kitchen-sink/x/'),
+            include: (path) => path.includes(`kitchen-sink${v}x${v}`),
             exclude: (_, filename) => filename.endsWith('.json'),
             visit: (value, path, filename) => {
 
@@ -391,7 +394,7 @@ describe('MoWalk', () => {
         await expect(Mo.walk(module, 'closet/multiple-index', {
             stopAtIndexes: true,
             visit: () => null
-        })).to.reject(AssertionError, /^Multiple index entries found in .+?\/multiple-index\/x: index\.js, index\.mjs\.$/);
+        })).to.reject(AssertionError, /^Multiple index entries found in .+?[\/\\]multiple-index[\/\\]x: index\.js, index\.mjs\.$/);
     });
 
     it('fails when failing to specific visit option correctly.', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -33,7 +33,13 @@ describe('MoWalk', () => {
         };
     });
 
-    const relativize = (filename) => Path.relative(Path.join(__dirname, 'closet'), filename);
+    const relativize = (filename) => {
+
+        return Path.relative(Path.join(__dirname, 'closet'), filename)
+            .split(Path.sep)        // Normalize to posix,
+            .join(Path.posix.sep);  // even if paths are windows
+    };
+
     const closet = (path) => Path.resolve(__dirname, 'closet', path);
     const byPath = ([,pathA], [,pathB]) => {
 


### PR DESCRIPTION
Following from https://github.com/nodejs/node/issues/31710, fixed `import()`s on windows.  The tests needed some updating to accommodate the different path separator from mac/linux.